### PR TITLE
Fix/minor styling fixes

### DIFF
--- a/404.html
+++ b/404.html
@@ -9,7 +9,7 @@ layout: page
     max-width: 600px;
     text-align: center;
   }
-  h1 {
+  .container h1 {
     margin: 30px 0;
     font-size: 4em;
     line-height: 1;

--- a/_sass/foundation/_base.sass
+++ b/_sass/foundation/_base.sass
@@ -39,18 +39,21 @@ body
     position: fixed
     display: block
     z-index: calc(var(--z-index-global-navigation) + 1)
+    pointer-events: none
   &::before
-    width: 100vw
     top: var(--gap)
-    left: 0
+    left: calc(var(--gap) * -1)
+    right: calc(var(--gap) * -1)
+    bottom: var(--gap)
     border-top: 1px solid #0005
-    box-shadow: 0 calc(100vh - var(--gap) * 2) 0 #0005
+    border-bottom: 1px solid #0005
   &::after
-    height: 100vh
-    top: 0
+    top: calc(var(--gap) * -1)
     left: var(--gap)
+    right: var(--gap)
+    bottom: calc(var(--gap) * -1)
     border-left: 1px solid #0005
-    box-shadow: calc(100vw - var(--gap) * 2) 0 0 #0005
+    border-right: 1px solid #0005
 
 // Links
 a

--- a/_sass/object/component/_tag-stats-bar.sass
+++ b/_sass/object/component/_tag-stats-bar.sass
@@ -3,6 +3,7 @@
 
   > .inner
     padding-bottom: 60px
+    padding-left: 1rem
     box-sizing: content-box
     vertical-align: bottom
     column-gap: 0.5rem
@@ -21,4 +22,3 @@
         bottom: 0
         transform-origin: 0 0
         transform: rotate(30deg) translate(7px, 15px)
-

--- a/_sass/object/project/_DatasetsSortFilterView.sass
+++ b/_sass/object/project/_DatasetsSortFilterView.sass
@@ -15,7 +15,7 @@
       width: calc(100% - 40px)
       // min-width: 12rem
       // max-width: 22rem
-      padding: 6px 10px
+      padding: 5px 10px
       font-size: 1.3rem
       border-radius: 6px
       border: 1px solid rgba(0,0,0,0.2)

--- a/_sass/object/project/_StatisticsTableView.sass
+++ b/_sass/object/project/_StatisticsTableView.sass
@@ -19,6 +19,39 @@
           > th
             cursor: pointer
             border-bottom: solid 1px #000
+            padding-right: 16px
+            &[data-sort]
+              > .th-label
+                position: relative
+                padding-right: 3px
+                &::before, &::after
+                  content: ''
+                  position: absolute
+                  left: calc(100% + 2px)
+                  color: #bbb
+                  font-size: 0.45em
+                  line-height: 1
+                  pointer-events: none
+                  transform: scaleX(1.8)
+                  transform-origin: left center
+                &::before
+                  content: '▲'
+                  top: 2px
+                &::after
+                  content: '▼'
+                  bottom: 2px
+              &.asc
+                > .th-label
+                  &::before
+                    color: #000
+                  &::after
+                    color: #bbb
+              &.desc
+                > .th-label
+                  &::before
+                    color: #bbb
+                  &::after
+                    color: #000
       > tbody
         > tr
           > td

--- a/assets/js/DatasetCard.js
+++ b/assets/js/DatasetCard.js
@@ -111,13 +111,16 @@ class DatasetCard {
     // updates document.documentElement.lang.
     try {
       // disconnect existing observer if present
-      if (this.#languageChangeHandler && typeof this.#languageChangeHandler.disconnect === 'function') {
+      if (
+        this.#languageChangeHandler &&
+        typeof this.#languageChangeHandler.disconnect === "function"
+      ) {
         this.#languageChangeHandler.disconnect();
       }
 
       const observer = new MutationObserver((mutations) => {
         for (const m of mutations) {
-          if (m.type === 'attributes' && m.attributeName === 'lang') {
+          if (m.type === "attributes" && m.attributeName === "lang") {
             if (this.#element) {
               this.#element.innerHTML = this.#generateContent();
               this.#setupEventListeners(this.#element);
@@ -126,7 +129,10 @@ class DatasetCard {
           }
         }
       });
-      observer.observe(document.documentElement, { attributes: true, attributeFilter: ['lang'] });
+      observer.observe(document.documentElement, {
+        attributes: true,
+        attributeFilter: ["lang"],
+      });
       this.#languageChangeHandler = observer;
     } catch (e) {
       // Fallback: no observer available, leave handler null.
@@ -156,12 +162,12 @@ class DatasetCard {
     // イベントリスナーをクリーンアップ
     if (this.#languageChangeHandler) {
       try {
-        if (typeof this.#languageChangeHandler.disconnect === 'function') {
+        if (typeof this.#languageChangeHandler.disconnect === "function") {
           this.#languageChangeHandler.disconnect();
         } else {
           // noop
         }
-      } catch (e) { }
+      } catch (e) {}
       this.#languageChangeHandler = null;
     }
 
@@ -189,7 +195,9 @@ class DatasetCard {
     const tripleCount = this.#dataset.statistics?.number_of_triples;
     let html = '<div class="meta">';
     if (issued) {
-      html += `<span class="issued">${this.#escapeHtml(issued)}</span>`;
+      html += `<span class="issued">Last update: ${this.#escapeHtml(
+        issued
+      )}</span>`;
     }
     if (tripleCount && typeof tripleCount === "number") {
       html += `<span class="triples">${tripleCount.toLocaleString()} triples</span>`;
@@ -210,9 +218,9 @@ class DatasetCard {
     ) {
       const href = this.#escapeHtml(
         this.#options.linkBaseUrl.replace(/\/$/, "") +
-        "/dataset/" +
-        encodeURIComponent(this.#dataset.id) +
-        "/",
+          "/dataset/" +
+          encodeURIComponent(this.#dataset.id) +
+          "/"
       );
       return `<a class="${DatasetCard.TITLE_CLASS} ${DatasetCard.LINK_CLASS}" href="${href}">${safe}</a>`;
     }
@@ -242,13 +250,14 @@ class DatasetCard {
 
     if (desc)
       return `<div class="${DatasetCard.DESCRIPTION_CLASS}">${this.#escapeHtml(
-        desc,
+        desc
       )}</div>`;
     if (this.#options.showFallbackDescription)
-      return `<div class="${DatasetCard.DESCRIPTION_CLASS
-        } isFallback">${this.#escapeHtml(
-          DatasetCard.DEFAULTS.FALLBACK_DESCRIPTION,
-        )}</div>`;
+      return `<div class="${
+        DatasetCard.DESCRIPTION_CLASS
+      } isFallback">${this.#escapeHtml(
+        DatasetCard.DEFAULTS.FALLBACK_DESCRIPTION
+      )}</div>`;
     return "";
   }
 
@@ -265,15 +274,17 @@ class DatasetCard {
   }
   #renderTag(tag) {
     if (typeof tag === "string")
-      return `<span class="${DatasetCard.TAG_CLASS
-        }" data-tag="${this.#escapeHtml(tag)}">${this.#escapeHtml(tag)}</span>`;
+      return `<span class="${
+        DatasetCard.TAG_CLASS
+      }" data-tag="${this.#escapeHtml(tag)}">${this.#escapeHtml(tag)}</span>`;
     if (tag && typeof tag === "object" && tag.id) {
       const lang = document.documentElement.lang || "ja";
       const txt = tag.label?.[lang] || tag.label?.ja || tag.label?.en || tag.id;
-      return `<span class="${DatasetCard.TAG_CLASS
-        }" data-tag="${this.#escapeHtml(tag.id)}">${this.#escapeHtml(
-          txt,
-        )}</span>`;
+      return `<span class="${
+        DatasetCard.TAG_CLASS
+      }" data-tag="${this.#escapeHtml(tag.id)}">${this.#escapeHtml(
+        txt
+      )}</span>`;
     }
     return "";
   }
@@ -287,18 +298,18 @@ class DatasetCard {
   #extractTagStrings(list) {
     return Array.isArray(list)
       ? list
-        .map((t) => (typeof t === "string" ? t : t?.id || ""))
-        .filter(Boolean)
+          .map((t) => (typeof t === "string" ? t : t?.id || ""))
+          .filter(Boolean)
       : [];
   }
   #escapeHtml(str) {
     return typeof str === "string"
       ? str
-        .replace(/&/g, "&amp;")
-        .replace(/</g, "&lt;")
-        .replace(/>/g, "&gt;")
-        .replace(/"/g, "&quot;")
-        .replace(/'/g, "&#39;")
+          .replace(/&/g, "&amp;")
+          .replace(/</g, "&lt;")
+          .replace(/>/g, "&gt;")
+          .replace(/"/g, "&quot;")
+          .replace(/'/g, "&#39;")
       : "";
   }
   #hashString(str) {
@@ -315,7 +326,10 @@ class DatasetCard {
     const size = this.#options.iconSize || 48;
     const tags = this.#extractTagStrings(this.#getTags());
     try {
-      if (window.DatasetIcon && typeof window.DatasetIcon.createSvg === 'function') {
+      if (
+        window.DatasetIcon &&
+        typeof window.DatasetIcon.createSvg === "function"
+      ) {
         return window.DatasetIcon.createSvg(tags, size, {});
       }
     } catch (e) {

--- a/datasets.md
+++ b/datasets.md
@@ -5,15 +5,12 @@ pageId: datasets
 description: 利用可能なRDFデータセットの一覧を表示します
 ---
 
-
-
 <!-- JekyllでJSONデータを埋め込む -->
-{% include datasets-json.html %}
 
+{% include datasets-json.html %}
 
 <!-- #DatasetsSortFilterView（default.html側）を活用するため独自UIは廃止 -->
 <div id="DatasetsListView"></div>
-
 
 <script>
 
@@ -133,6 +130,14 @@ document.addEventListener('DOMContentLoaded', async function() {
     if (e.target.matches('button[data-sort]')) {
       sortSegment.querySelectorAll('button').forEach(btn => btn.setAttribute('aria-pressed', 'false'));
       e.target.setAttribute('aria-pressed', 'true');
+      if (sortOrderSegment) {
+        const sortKey = e.target.getAttribute('data-sort');
+        const desiredOrder = sortKey === 'name' ? 'asc' : 'desc';
+        sortOrderSegment.querySelectorAll('button').forEach(btn => {
+          const isTarget = btn.getAttribute('data-order') === desiredOrder;
+          btn.setAttribute('aria-pressed', isTarget ? 'true' : 'false');
+        });
+      }
       renderDatasets(getFilteredSortedDatasets());
     }
   });

--- a/sparql_endpoints.md
+++ b/sparql_endpoints.md
@@ -26,7 +26,7 @@ permalink: /sparql_endpoints/
             {% for dataset in site.data.datasets %}
               {% if dataset.endpoint == endpoint.id %}
                 <li>
-                  <a href="{{ site.baseurl }}/dataset/?id={{ dataset.id | url_encode }}">
+                  <a href="{{ site.baseurl }}/dataset/{{ dataset.id | url_encode }}">
                     {{ dataset.title }}
                   </a>
                 </li>

--- a/statistics.md
+++ b/statistics.md
@@ -13,15 +13,15 @@ permalink: /statistics/
     <table>
       <thead>
         <tr>
-          <th data-sort="title">Dataset</th>
-          <th data-sort="number_of_triples">Triples</th>
-          <th data-sort="number_of_links">Links</th>
-          <th data-sort="number_of_classes">Classes</th>
-          <th data-sort="number_of_instances">Instances</th>
-          <th data-sort="number_of_literals">Literals</th>
-          <th data-sort="number_of_subjects">Subjects</th>
-          <th data-sort="number_of_properties">Properties</th>
-          <th data-sort="number_of_objects">Objects</th>
+          <th data-sort="title"><span class="th-label">Dataset</span></th>
+          <th data-sort="number_of_triples"><span class="th-label">Triples</span></th>
+          <th data-sort="number_of_links"><span class="th-label">Links</span></th>
+          <th data-sort="number_of_classes"><span class="th-label">Classes</span></th>
+          <th data-sort="number_of_instances"><span class="th-label">Instances</span></th>
+          <th data-sort="number_of_literals"><span class="th-label">Literals</span></th>
+          <th data-sort="number_of_subjects"><span class="th-label">Subjects</span></th>
+          <th data-sort="number_of_properties"><span class="th-label">Properties</span></th>
+          <th data-sort="number_of_objects"><span class="th-label">Objects</span></th>
         </tr>
       </thead>
       <tbody>


### PR DESCRIPTION
マイナー修正：
- 404ページのメニュータイトルを修正
- バックグラウンドの右・下ボーダーを box-shadow から border に変更
- statisticsページのグラフテキストを修正
- datasetsページのフィルターボックスのテキスト表示を修正
- datasetsページに「最終更新」テキストを追加
- sparql_endpointsページのリンクを修正

機能追加：
- statisticsページにテーブルソート機能を追加
- datasetsページの名前ソートのデフォルトを「Asc（昇順）」に設定